### PR TITLE
Fix navigator transition

### DIFF
--- a/lib/multi_navigator_bottom_bar.dart
+++ b/lib/multi_navigator_bottom_bar.dart
@@ -104,6 +104,7 @@ class TabPageNavigator extends StatelessWidget {
         onGenerateRoute: (routeSettings) =>
             pageRoute ??
             MaterialPageRoute(
+              settings: RouteSettings(isInitialRoute: true),
               builder: (context) =>
                   _defaultPageRouteBuilder(routeSettings.name)(context),
             ),


### PR DESCRIPTION
This fixes a bug with transitions.

How to reproduce before this fix:
* When you start the example you can see first page transitioning in horizontally.
* Same can be senn when returning from a subpage(`Navigator.of(context).pop()`)
